### PR TITLE
Dev

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { Sekolah } from "@/types/school";
 import L from "leaflet";
 import RoutingSidebar from "./map/RoutingSidebar";
 import { FaRoute } from "react-icons/fa6";
+import { RouteInfo } from "./map/RoutingControl"; // Add this import for RouteInfo
 
 interface SidebarProps {
   isOpen: boolean;

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -11,38 +11,35 @@ import LocationControl from "./LocationControl";
 import RoutingControl, { RouteInfo } from "./RoutingControl";
 import { useLocation } from "@/contexts/LocationContext";
 
-// Create marker icons after import
-// @ts-ignore
+// Create marker icons after import with proper type assertion
 const defaultIcon = L.icon({
   iconUrl: "/leaflet/marker-icon.png",
-  // iconRetinaUrl: "/leaflet/marker-icon-2x.png",
+  iconRetinaUrl: "/leaflet/marker-icon-2x.png",
   shadowUrl: "/leaflet/marker-shadow.png",
   iconSize: [25, 41],
   iconAnchor: [12, 41],
   popupAnchor: [1, -34],
-  // shadowSize: [41, 41],
-});
+  shadowSize: [41, 41],
+} as any); // Use 'any' to bypass type checking for icon properties
 
-// @ts-ignore
 const redMarkerIcon = L.icon({
   iconUrl: "/marker/marker-icon-red.png",
-  // iconRetinaUrl: "/marker/marker-icon-2x-red.png",
+  iconRetinaUrl: "/marker/marker-icon-2x-red.png",
   shadowUrl: "/leaflet/marker-shadow.png",
   iconSize: [25, 41],
   iconAnchor: [12, 41],
   popupAnchor: [1, -34],
-  // shadowSize: [41, 41],
-});
+  shadowSize: [41, 41],
+} as any); // Use 'any' to bypass type checking for icon properties
 
 // Add location icon for user location marker
-// @ts-ignore
 const locationIcon = L.icon({
   iconUrl: "/marker/location.png",
   shadowUrl: "/leaflet/marker-shadow.png",
   iconSize: [32, 32],
   iconAnchor: [16, 16],
   popupAnchor: [0, -16],
-});
+} as any); // Use 'any' to bypass type checking for icon properties
 
 // Add MapController component to handle map reference
 function MapController({ map }: { map: L.Map | null }) {


### PR DESCRIPTION
This pull request introduces updates to the `src/components/map` and `src/components` directories to improve type handling and streamline imports. The most important changes include adding a new import for `RouteInfo`, simplifying imports in `Map.tsx`, and addressing TypeScript type-checking issues for Leaflet marker icons.

### Import Updates:
* [`src/components/Sidebar.tsx`](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR6): Added an import for `RouteInfo` from `RoutingControl` to support additional functionality.
* [`src/components/map/Map.tsx`](diffhunk://#diff-4c6f3a32c46718d48a9634ef0ae21287e206c925ecbf614505b3e266a01bc6eaL7-R14): Simplified the `LayerSwitcher` import by removing the unused `MapLayerType`.

### TypeScript Type Handling:
* [`src/components/map/Map.tsx`](diffhunk://#diff-4c6f3a32c46718d48a9634ef0ae21287e206c925ecbf614505b3e266a01bc6eaL24-L26): Replaced `@ts-ignore` comments with explicit `as any` type assertions for Leaflet marker icons (`defaultIcon`, `redMarkerIcon`, and `locationIcon`) to bypass type-checking issues while maintaining clarity. [[1]](diffhunk://#diff-4c6f3a32c46718d48a9634ef0ae21287e206c925ecbf614505b3e266a01bc6eaL24-L26) [[2]](diffhunk://#diff-4c6f3a32c46718d48a9634ef0ae21287e206c925ecbf614505b3e266a01bc6eaL35-R42)