### PR TITLE
fix: Adjust Popup component structure for consistent styling in Schoo…

### DIFF
--- a/src/components/map/SchoolPopup.tsx
+++ b/src/components/map/SchoolPopup.tsx
@@ -11,8 +11,8 @@ export default function SchoolPopup({ school }: SchoolPopupProps) {
   const schoolColor = getSchoolColor(school.bentuk_pendidikan);
 
   return (
-    <Popup className="rounded-xl min-w-[280px]">
-      <div className="text-sm font-sans -mx-3 -my-2">
+    <Popup>
+      <div className="text-sm font-sans -mx-3 -my-2 rounded-xl min-w-[280px]">
         <div className={`${schoolColor.base} p-3 -mt-2 -mx-2 rounded-t-lg relative`}>
           <div className="absolute top-0 right-0 px-2 py-1 text-[10px] font-medium bg-black/20 text-white rounded-bl-lg">
             {school.bentuk_pendidikan}


### PR DESCRIPTION
This pull request modifies the `SchoolPopup` component to streamline the class attribute usage and improve the structure of the rendered elements.

Styling adjustments:

* [`src/components/map/SchoolPopup.tsx`](diffhunk://#diff-6274262ce950edec665c06080747f4dad9d2ba9837a517a182af5178f9c99ba9L14-R15): Moved the `rounded-xl` and `min-w-[280px]` classes from the `Popup` component to the inner `div` element for better organization and consistency in styling.